### PR TITLE
Add versioning with bump2version

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.0
+current_version = 0.1.1
 commit = True
 tag = True
 files = setup.py meld_classifier/__init__.py

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.1
+current_version = 0.1.2
 commit = True
 tag = True
 files = setup.py meld_classifier/__init__.py

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,8 @@
+[bumpversion]
+current_version = 0.1.0
+commit = True
+tag = True
+files = setup.py meld_classifier/__init__.py
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
+serialize = 
+	{major}.{minor}.{patch}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,9 +40,15 @@ Creating a relase
 We use `bump2version` (``pip install bump2version``) to keep track of version numbering. 
 Version numbers follow the convention of ``major.minor.patch``.
 
-To update the current version and create a new version tag, simply call:
+1. Create a new branch for this release:
+
+    git checkout -b release/VERSION
+
+2. Update the current version and create a new version tag:
 
     bump2version {major,minor,patch}
     git push --tags
 
-Edit and publish the relase on github (under the "tags" Tab) and add release notes.
+3. Create and merge a PR for the bump2version commit.
+
+4. Edit and publish the relase on github (under the "tags" Tab) and add release notes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,9 @@
-# Contributing guide
+Contributing guide
+~~~~~~~~~~~~~~~~~~
+
+Contributing to meld_classifier
+-------------------------------
+
 We use a pull-request based workflow. Do not push to master directly, to avoid having buggy, untested code.
 The general workflow is as follows:
 
@@ -20,7 +25,7 @@ The general workflow is as follows:
 	```
 	pytest
 	```
-	 There are some long tests, if you want to exlude them for quick testing, run `pytest -m "not slow"`. 
+	There are some long tests, if you want to exlude them for quick testing, run `pytest -m "not slow"`. 
 3. when finished developing, merge in new changes from master: (on `cool-new-feature` branch) 
 	```
 	git pull origin master
@@ -28,3 +33,16 @@ The general workflow is as follows:
 4. create a pull request on github and document all changes that you have done (also useful for looking at in the future). E.g. look at this example #3. Creating a PR works by going to your branch on the github webpage and pressing the "pull request" button. 
 5. squash & merge the PR into master. This replaces all the individual commits with 1 commit per PR which is helful for keeping a clean commit history on master and get rid of all the "bugfix" commit messages. Go to the PR on the github webpage and click on the down arrow on the merge button. Select `squash and merge` and click. 
 
+
+Creating a relase
+-----------------
+
+We use `bump2version` (``pip install bump2version``) to keep track of version numbering. 
+Version numbers follow the convention of ``major.minor.patch``.
+
+To update the current version and create a new version tag, simply call::
+
+    bump2version {major,minor,patch}
+    git push --tags
+
+Edit and publish the relase on github (under the "tags" Tab) and add release notes.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ For more details, check out the guides linked below:
 - [Train and evaluate models](Training_and_evaluating_models.md)
 
 ## Contribute
-If you'd like to contribute to this code base, have a look at our [contribution guide](DEVELOP.md)
+If you'd like to contribute to this code base, have a look at our [contribution guide](CONTRIBUTING.md)
 
 ## Manuscript
 Please check out our [manuscript](https://www.medrxiv.org/content/10.1101/2021.12.13.21267721v1) to learn more.

--- a/meld_classifier/__init__.py
+++ b/meld_classifier/__init__.py
@@ -1,0 +1,3 @@
+__author__ = __maintainer__ = "MELD development team"
+__email__ = "meld.study@gmail.com"
+__version__ = "0.1.0"

--- a/meld_classifier/__init__.py
+++ b/meld_classifier/__init__.py
@@ -1,3 +1,3 @@
 __author__ = __maintainer__ = "MELD development team"
 __email__ = "meld.study@gmail.com"
-__version__ = "0.1.1"
+__version__ = "0.1.2"

--- a/meld_classifier/__init__.py
+++ b/meld_classifier/__init__.py
@@ -1,3 +1,3 @@
 __author__ = __maintainer__ = "MELD development team"
 __email__ = "meld.study@gmail.com"
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ try:
 except ImportError:
     __author__ = __maintainer__ = "MELD development team"
     __email__ = "meld.study@gmail.com"
-    __version__ = "0.1.0"
+    __version__ = "0.1.1"
 
 setup(
     name="meld_classifier",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ try:
 except ImportError:
     __author__ = __maintainer__ = "MELD development team"
     __email__ = "meld.study@gmail.com"
-    __version__ = "0.1.1"
+    __version__ = "0.1.2"
 
 setup(
     name="meld_classifier",

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,21 @@
 from setuptools import setup, find_packages
 
+try:
+    from meld_classifier import __author__, __maintainer__, __email__, __version__
+except ImportError:
+    __author__ = __maintainer__ = "MELD development team"
+    __email__ = "meld.study@gmail.com"
+    __version__ = "0.1.0"
+
 setup(
     name="meld_classifier",
-    version="0.1",
+    version=__version__,
+    author=__author__,
+    author_email=__email__,
+    maintainer=__author__,
+    maintainer_email=__email__,
+    description="Neural network lesion classifier for the MELD project.",
+    license="MIT",
     packages=find_packages(),
     install_requires=["nibabel", "h5py", "pillow", "tensorflow", "pandas", "matplotlib"],
     package_dir={"meld_classifier": "meld_classifier"},


### PR DESCRIPTION
I propose to use bump2version for keeping track to version tags.

Basically, call `bump2version {major, minor,patch} to update all version strings in the code and create a version tag. 

 Changes in this PR:
- added .bump2version.cfg and a section in CONTRIBUTING.md (was DEVELOP.md before) on how to use it. 
- renamed meld_classifier/__ini__.py to meld_classifier/__init__.py
- added `__version__`, `__author__` and `__email__` attrs to meld_classifier in `__init__.py`. 
- added version, authors, and email to setup.py (info is now correctly displayed when using `pip show meld_classifier`)

I've also added a tag protection rule for version tags to GitHub, such that only admins and maintainers can update version tags.
